### PR TITLE
Fix Windows query string parsing

### DIFF
--- a/lua/dynomark/core.lua
+++ b/lua/dynomark/core.lua
@@ -177,7 +177,7 @@ local function execute_dynomark_query(query)
         result = handle:read("*a")
         handle:close()
     else
-        result = vim.fn.system(dynomark_bin .. " --query '" .. query .. "' 2>&1")
+        result = vim.fn.system(dynomark_bin .. ' --query "' .. query .. '" 2>&1')
     end
 
     return result:gsub("^%s*(.-)%s*$", "%1") -- Trim whitespace


### PR DESCRIPTION
## Summary

- Fix Windows query string parsing by using double quotes instead of single
    quotes
- Resolves dynomark query execution failures on Windows where PowerShell
    treats single quotes as literal characters

## Test plan

- Test dynomark query execution on Windows with various query strings
    - Tested on Windows 11 with NeoVim 11
- Verify non-Windows systems continue to work correctly
    - Tested on MacOS 15 with NeoVim 11